### PR TITLE
add com.github.xournalpp.xournalpp.svg

### DIFF
--- a/apps/16/com.github.xournalpp.xournalpp.svg
+++ b/apps/16/com.github.xournalpp.xournalpp.svg
@@ -1,0 +1,1 @@
+xournal.svg

--- a/apps/scalable/com.github.xournalpp.xournalpp.svg
+++ b/apps/scalable/com.github.xournalpp.xournalpp.svg
@@ -1,0 +1,1 @@
+xournal.svg

--- a/apps/symbolic/com.github.xournalpp.xournalpp-symbolic.svg
+++ b/apps/symbolic/com.github.xournalpp.xournalpp-symbolic.svg
@@ -1,0 +1,1 @@
+xournal-symbolic.svg


### PR DESCRIPTION
xournal doesn't show icon, xournal's .desktop file on github points to com.github.xournalpp.xournalpp


https://github.com/xournalpp/xournalpp/blob/master/desktop/com.github.xournalpp.xournalpp.desktop