### PR TITLE
Add a GitHub issue template for missing icon

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing_icon.md
+++ b/.github/ISSUE_TEMPLATE/missing_icon.md
@@ -1,0 +1,35 @@
+---
+name: Missing icon
+about: Proposal for a missing icon
+title: 'Missing icon: '
+---
+
+<!--
+If You'll find a missing icon please open a new issue and give as much information as You can:
+
+1. If it's a program, please provide name and link to the website or repository page.
+2. If You can, find a link to the original svg icon.
+3. Output of the xprop and/or link to .desktop file (located in .local/share/applications folder).
+-->
+
+## Program
+
+- name: 
+- website:
+
+## Original icon
+<!-- copy-paste icon here -->
+
+## :technologist: Technical details
+
+- Operating System: 
+- Desktop Environment: 
+- Program Installation: 
+
+<!--
+Run xprop in a terminal, then click on the application window, and copy-paste the output here.
+-->
+
+<!--
+Additionally, you can link to `.desktop` file (located in `.local/share/applications` folder).
+-->


### PR DESCRIPTION
Here's an issue template to help contributors open new reports for missing icons.