### PR TITLE
org.gnome.Snapshot link to screenshot.svg

### DIFF
--- a/Gruvbox-Plus-Dark/apps/16/org.gnome.Snapshot.svg
+++ b/Gruvbox-Plus-Dark/apps/16/org.gnome.Snapshot.svg
@@ -1,0 +1,1 @@
+screenshot.svg

--- a/Gruvbox-Plus-Dark/apps/scalable/org.gnome.Snapshot.svg
+++ b/Gruvbox-Plus-Dark/apps/scalable/org.gnome.Snapshot.svg
@@ -1,0 +1,1 @@
+screenshot.svg

--- a/Gruvbox-Plus-Light/apps/16/org.gnome.Snapshot.svg
+++ b/Gruvbox-Plus-Light/apps/16/org.gnome.Snapshot.svg
@@ -1,0 +1,1 @@
+screenshot.svg


### PR DESCRIPTION
Hi! In NixOS, I have `Icon=org.gnome.Snapshot` in [Snapshot](https://gitlab.gnome.org/GNOME/snapshot) instead of `Icon=snapshot`.

So, I made a pr with this link