### PR TITLE
add symlinks for application-vnd.efi.iso

### DIFF
--- a/Gruvbox-Plus-Dark/mimetypes/16/application-vnd.efi.iso.svg
+++ b/Gruvbox-Plus-Dark/mimetypes/16/application-vnd.efi.iso.svg
@@ -1,0 +1,1 @@
+x-content-blank-cd.svg

--- a/Gruvbox-Plus-Dark/mimetypes/scalable/application-vnd.efi.iso.svg
+++ b/Gruvbox-Plus-Dark/mimetypes/scalable/application-vnd.efi.iso.svg
@@ -1,0 +1,1 @@
+application-x-cd-image.svg

--- a/Gruvbox-Plus-Light/mimetypes/16/application-vnd.efi.iso.svg
+++ b/Gruvbox-Plus-Light/mimetypes/16/application-vnd.efi.iso.svg
@@ -1,0 +1,1 @@
+x-content-blank-cd.svg


### PR DESCRIPTION
Add missing symlinks for the `application/vnd.efi.iso` mimetype, this includes linux isos and more.