### PR TITLE
Removes whitespace for "Inherits" in index.theme

### DIFF
--- a/Gruvbox-Plus-Dark/index.theme
+++ b/Gruvbox-Plus-Dark/index.theme
@@ -44,7 +44,7 @@
 Name=Gruvbox Plus Dark
 Comment=Icon pack with gruvbox colors for dark themes
 
-Inherits=breeze-dark, hicolor
+Inherits=breeze-dark,hicolor
 
 Example=folder
 

--- a/Gruvbox-Plus-Light/index.theme
+++ b/Gruvbox-Plus-Light/index.theme
@@ -44,7 +44,7 @@
 Name=Gruvbox Plus Light
 Comment=Icon pack with gruvbox colors for light themes
 
-Inherits=Gruvbox-Plus-Dark, breeze, hicolor
+Inherits=Gruvbox-Plus-Dark,breeze,hicolor
 
 Example=folder
 


### PR DESCRIPTION
# Overview

I noticed recently that some applications were spamming the following in my logs:

```
kf.iconthemes: Icon theme " hicolor" not found.
```

After spinning my wheels for a while since I have `hicolor` fallback theme installed, I realized that there is an extra whitespace before the word in quotes.

This led me to try to find where ` hicolor` (with a leading space) could be in my configuration.

After digging around I realized that in both the Gruvbox Plus Dark and Light theme files, the `Inherits` property has extra spaces around the inherited themes. Removing the extra spaces in `~/.local/share/icons/Gruvbox-Plus_dark/index.theme` seems to have resolved the problems I was seeing on my system.

I assume this is maybe some kind of upstream change in KDE or elsewhere that changed how the `Inherits` string gets interpreted.

# Other details

```
Operating System: Arch Linux 
KDE Plasma Version: 6.6.4
KDE Frameworks Version: 6.25.0
Qt Version: 6.11.0
Kernel Version: 6.19.11-arch1-1 (64-bit)
```