### PR TITLE
Give window-restore its own icon instead of reusing window-maximize

### DIFF
--- a/Gruvbox-Plus-Dark/actions/16/window-restore.svg
+++ b/Gruvbox-Plus-Dark/actions/16/window-restore.svg
@@ -2,5 +2,5 @@
   <defs>
     <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#ebdbb2; } .ColorScheme-Highlight { color:#458588; }</style>
   </defs>
-  <path class="ColorScheme-Text" d="m5 4c-0.554 0-1 0.446-1 1v6c0 0.554 0.446 1 1 1h6c0.554 0 1-0.446 1-1v-6c0-0.554-0.446-1-1-1zm1.5 3h3c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-3c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
+  <path class="ColorScheme-Text" d="m7 3c-0.554 0-1 0.446-1 1v1h5v5h2v-6c0-0.554-0.446-1-1-1zm-3 3c-0.554 0-1 0.446-1 1v5c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-5c0-0.554-0.446-1-1-1zm1.5 2h2c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-2c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
 </svg>

--- a/Gruvbox-Plus-Dark/actions/16/xfce-wm-unmaximize.svg
+++ b/Gruvbox-Plus-Dark/actions/16/xfce-wm-unmaximize.svg
@@ -1,1 +1,1 @@
-window-maximize.svg
+window-restore.svg

--- a/Gruvbox-Plus-Dark/actions/22/window-restore.svg
+++ b/Gruvbox-Plus-Dark/actions/22/window-restore.svg
@@ -2,5 +2,5 @@
   <defs>
     <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#ebdbb2; } .ColorScheme-Highlight { color:#458588; }</style>
   </defs>
-  <path class="ColorScheme-Text" d="m8 7c-0.554 0-1 0.446-1 1v6c0 0.554 0.446 1 1 1h6c0.554 0 1-0.446 1-1v-6c0-0.554-0.446-1-1-1zm1.5 3h3c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-3c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
+  <path class="ColorScheme-Text" d="m10 6c-0.554 0-1 0.446-1 1v1h5v5h2v-6c0-0.554-0.446-1-1-1zm-3 3c-0.554 0-1 0.446-1 1v5c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-5c0-0.554-0.446-1-1-1zm1.5 2h2c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-2c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
 </svg>

--- a/Gruvbox-Plus-Dark/actions/22/xfce-wm-unmaximize.svg
+++ b/Gruvbox-Plus-Dark/actions/22/xfce-wm-unmaximize.svg
@@ -1,1 +1,1 @@
-window-maximize.svg
+window-restore.svg

--- a/Gruvbox-Plus-Dark/actions/24/window-restore.svg
+++ b/Gruvbox-Plus-Dark/actions/24/window-restore.svg
@@ -2,5 +2,5 @@
   <defs>
     <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#ebdbb2; } .ColorScheme-Highlight { color:#458588; }</style>
   </defs>
-  <path class="ColorScheme-Text" d="m9 8c-0.554 0-1 0.446-1 1v6c0 0.554 0.446 1 1 1h6c0.554 0 1-0.446 1-1v-6c0-0.554-0.446-1-1-1zm1.5 3h3c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-3c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
+  <path class="ColorScheme-Text" d="m11 7c-0.554 0-1 0.446-1 1v1h5v5h2v-6c0-0.554-0.446-1-1-1zm-3 3c-0.554 0-1 0.446-1 1v5c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-5c0-0.554-0.446-1-1-1zm1.5 2h2c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-2c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
 </svg>

--- a/Gruvbox-Plus-Dark/actions/24/xfce-wm-unmaximize.svg
+++ b/Gruvbox-Plus-Dark/actions/24/xfce-wm-unmaximize.svg
@@ -1,1 +1,1 @@
-window-maximize.svg
+window-restore.svg

--- a/Gruvbox-Plus-Dark/actions/symbolic/window-restore-symbolic-rtl.svg
+++ b/Gruvbox-Plus-Dark/actions/symbolic/window-restore-symbolic-rtl.svg
@@ -1,1 +1,1 @@
-window-maximize-symbolic.svg
+window-restore-symbolic.svg

--- a/Gruvbox-Plus-Dark/actions/symbolic/window-restore-symbolic.svg
+++ b/Gruvbox-Plus-Dark/actions/symbolic/window-restore-symbolic.svg
@@ -1,1 +1,6 @@
-window-maximize-symbolic.svg
+<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#ebdbb2; } .ColorScheme-Highlight { color:#458588; }</style>
+  </defs>
+  <path class="ColorScheme-Text" d="m7 3c-0.554 0-1 0.446-1 1v1h5v5h2v-6c0-0.554-0.446-1-1-1zm-3 3c-0.554 0-1 0.446-1 1v5c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-5c0-0.554-0.446-1-1-1zm1.5 2h2c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-2c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
+</svg>

--- a/Gruvbox-Plus-Light/actions/16/window-restore.svg
+++ b/Gruvbox-Plus-Light/actions/16/window-restore.svg
@@ -2,5 +2,5 @@
   <defs>
     <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#282828; } .ColorScheme-Highlight { color:#458588; }</style>
   </defs>
-  <path class="ColorScheme-Text" d="m5 4c-0.554 0-1 0.446-1 1v6c0 0.554 0.446 1 1 1h6c0.554 0 1-0.446 1-1v-6c0-0.554-0.446-1-1-1zm1.5 3h3c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-3c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
+  <path class="ColorScheme-Text" d="m7 3c-0.554 0-1 0.446-1 1v1h5v5h2v-6c0-0.554-0.446-1-1-1zm-3 3c-0.554 0-1 0.446-1 1v5c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-5c0-0.554-0.446-1-1-1zm1.5 2h2c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-2c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
 </svg>

--- a/Gruvbox-Plus-Light/actions/16/xfce-wm-unmaximize.svg
+++ b/Gruvbox-Plus-Light/actions/16/xfce-wm-unmaximize.svg
@@ -1,1 +1,1 @@
-window-maximize.svg
+window-restore.svg

--- a/Gruvbox-Plus-Light/actions/22/window-restore.svg
+++ b/Gruvbox-Plus-Light/actions/22/window-restore.svg
@@ -2,5 +2,5 @@
   <defs>
     <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#282828; } .ColorScheme-Highlight { color:#458588; }</style>
   </defs>
-  <path class="ColorScheme-Text" d="m8 7c-0.554 0-1 0.446-1 1v6c0 0.554 0.446 1 1 1h6c0.554 0 1-0.446 1-1v-6c0-0.554-0.446-1-1-1zm1.5 3h3c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-3c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
+  <path class="ColorScheme-Text" d="m10 6c-0.554 0-1 0.446-1 1v1h5v5h2v-6c0-0.554-0.446-1-1-1zm-3 3c-0.554 0-1 0.446-1 1v5c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-5c0-0.554-0.446-1-1-1zm1.5 2h2c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-2c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
 </svg>

--- a/Gruvbox-Plus-Light/actions/22/xfce-wm-unmaximize.svg
+++ b/Gruvbox-Plus-Light/actions/22/xfce-wm-unmaximize.svg
@@ -1,1 +1,1 @@
-window-maximize.svg
+window-restore.svg

--- a/Gruvbox-Plus-Light/actions/24/window-restore.svg
+++ b/Gruvbox-Plus-Light/actions/24/window-restore.svg
@@ -2,5 +2,5 @@
   <defs>
     <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#282828; } .ColorScheme-Highlight { color:#458588; }</style>
   </defs>
-  <path class="ColorScheme-Text" d="m9 8c-0.554 0-1 0.446-1 1v6c0 0.554 0.446 1 1 1h6c0.554 0 1-0.446 1-1v-6c0-0.554-0.446-1-1-1zm1.5 3h3c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-3c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
+  <path class="ColorScheme-Text" d="m11 7c-0.554 0-1 0.446-1 1v1h5v5h2v-6c0-0.554-0.446-1-1-1zm-3 3c-0.554 0-1 0.446-1 1v5c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-5c0-0.554-0.446-1-1-1zm1.5 2h2c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-2c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
 </svg>

--- a/Gruvbox-Plus-Light/actions/24/xfce-wm-unmaximize.svg
+++ b/Gruvbox-Plus-Light/actions/24/xfce-wm-unmaximize.svg
@@ -1,1 +1,1 @@
-window-maximize.svg
+window-restore.svg

--- a/Gruvbox-Plus-Light/actions/symbolic/window-restore-symbolic-rtl.svg
+++ b/Gruvbox-Plus-Light/actions/symbolic/window-restore-symbolic-rtl.svg
@@ -1,1 +1,1 @@
-window-maximize-symbolic.svg
+window-restore-symbolic.svg

--- a/Gruvbox-Plus-Light/actions/symbolic/window-restore-symbolic.svg
+++ b/Gruvbox-Plus-Light/actions/symbolic/window-restore-symbolic.svg
@@ -1,1 +1,6 @@
-window-maximize-symbolic.svg
+<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#282828; } .ColorScheme-Highlight { color:#458588; }</style>
+  </defs>
+  <path class="ColorScheme-Text" d="m7 3c-0.554 0-1 0.446-1 1v1h5v5h2v-6c0-0.554-0.446-1-1-1zm-3 3c-0.554 0-1 0.446-1 1v5c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-5c0-0.554-0.446-1-1-1zm1.5 2h2c0.277 0 0.5 0.223 0.5 0.5v2c0 0.277-0.223 0.5-0.5 0.5h-2c-0.277 0-0.5-0.223-0.5-0.5v-2c0-0.277 0.223-0.5 0.5-0.5z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
### Problem

`window-restore` is visually identical to `window-maximize`:

* `actions/symbolic/window-restore-symbolic.svg` and `window-restore-symbolic-rtl.svg` are symlinks to `window-maximize-symbolic.svg`.
* `actions/{16,22,24}/window-restore.svg` are real files, but they differ from `window-maximize.svg` only in the height of the inner cut-out, `v2` instead of `v3`. That is one pixel, and it is not visible at icon size.

A titlebar button that should change once the window is maximized therefore never does. I ran into this on KDE Plasma with the Klassy decoration set to "System icon theme" button icons: the maximize button looks the same whether the window is maximized or not. Anything else that consumes the standard icon names is affected the same way.

### Fix

Redraw `window-restore` as two offset squares, the composition the icon has in Suru, which this pack is based on. It uses this pack's own 2px stroke and corner radius, written in the same relative-path idiom as `window-maximize.svg`, so it matches the other `window-*` icons.

Two related symlinks are fixed as well:

* `actions/{16,22,24}/xfce-wm-unmaximize.svg` pointed at `window-maximize.svg`. xfwm's "unmaximize" is the restore action, so it had the same problem. It now points at `window-restore.svg`.
* `window-restore-symbolic-rtl.svg` now points at `window-restore-symbolic.svg`, matching how `window-maximize-symbolic-rtl.svg` is handled.

Both Dark and Light are updated. `window-maximize` is untouched.
